### PR TITLE
updates fileutiles.walk to use glob

### DIFF
--- a/Lib/hTools2/modules/fileutils.py
+++ b/Lib/hTools2/modules/fileutils.py
@@ -4,6 +4,7 @@
 
 # imports
 
+import glob
 import os
 import shutil
 
@@ -11,14 +12,8 @@ import shutil
 
 def walk(folder, extension):
     '''A simple non-recursive `walk` function to collect files with a given extension.'''
-    files = []
-    names = os.listdir(folder)
-    for n in names:
-        p = os.path.join(folder, n)
-        file_name, file_extension = os.path.splitext(n)
-        if file_extension[1:] == extension:
-            files.append(p)
-    return files
+    folder = folder if not folder.endswith("/") else folder[:-1]
+    return glob.glob("%s/*.%s" % (folder, extension))
 
 def get_names_from_path(fontpath):
     '''Parse underscore(or hyphen)-separated font file names into `family` and `style` names.'''


### PR DESCRIPTION
tested with python 2.6 and 2.7, glob appears way back in 2.3, but i don't know what version of python htools is targeting (presumably whatever robofont uses?)

(also, apologies for these softball pull reqs, i'm trying to get up to speed on robofont scripting this weekend and just started diving into htools since it seems fairly comprehensive. additionally, if there _is_ some part of htools you'd like help with, i'm happy to help out any way i can)
