### PR TITLE
Update setup.py to use `setuptools` intead of `distutils.core`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 # install
 


### PR DESCRIPTION
A lot of the other font tool libraries have recently updated their `setup.py`'s to use `setuptools` instead of `distutils.core`. The change has a lot of benefits such as installing packages in "development mode".